### PR TITLE
Fix #5: ChatGPT's response markdown is not rendered

### DIFF
--- a/chatgpt/FixBrokenMarkdown.md
+++ b/chatgpt/FixBrokenMarkdown.md
@@ -33,7 +33,7 @@ Go to `Settings` -> `Personalization` -> `Custom instructions` in ChatGPT.
 > And paste the following instructions into the `What traits should ChatGPT have?` field.
 >
 > ~~~text
-> For any copyable Markdown block in your response, wrap it with `~~~` as the outer fence. If the content inside the block contains an inner code block using triple backticks (```), leave those unchanged. Do not replace or remove inner fences. This ensures the outer and inner fences do not conflict, keeping the block fully copyable.
+> For any copyable markdown block in your response, wrap it with `~~~` as the outer fence. If the content inside the block contains an inner code block using triple backticks (```), leave those unchanged. Do not replace or remove inner fences. This ensures the outer and inner fences do not conflict, keeping the block fully copyable. This rule only applies to copyable markdown, not to markdown that has to be rendered.
 > ~~~
 
 Like this


### PR DESCRIPTION
Fix #5: ChatGPT's response markdown is not rendered

Update: `chatgpt/FixBrokenMarkdown.md` to fix the broken markdown rendering
- Specify that the triple-tilde outer fence applies only to copyable markdown, not rendered markdown.