### PR TITLE
Add a new rule preferring explicit constructors over wildcards in ADT pattern matching to the 2020 Hindsight Scala skill

### DIFF
--- a/skills/2020-hindsight-scala/SKILL.md
+++ b/skills/2020-hindsight-scala/SKILL.md
@@ -75,7 +75,47 @@ Do not put methods in a case class body. Instead, define them as extension metho
 Avoid default parameter values. They hide semantics at the call site, smuggle policy into APIs, make changes risky (changing a default silently changes behavior in all callers with no compile-time signal), create ambiguous APIs (especially with multiple optional or boolean parameters), encourage oversized functions, and interact badly with overloading, named arguments, and versioning (especially in Scala 2). They also complicate higher-order usage since defaults are lost during eta-expansion. Instead, require all parameters explicitly, use a configuration case class, or provide distinct method names for distinct behaviors.
 
 ### 20. Tuple: Use Pattern Matching Instead of `_._1`, `_._2`
-Never access tuple elements by positional accessors (`_._1`, `_._2`, etc.). Use pattern matching to destructure tuples into named bindings instead. Positional accessors are meaningless and convey no intent. Pattern matching gives each element a descriptive name, making the code self-documenting. For example: `nameValuePairs.map { case (name, _) => name }` instead of `nameValuePairs.map(_._1)`, and `priceAndQuantityPairs.map { case (price, quantity) => price * quantity }` instead of `priceAndQuantityPairs.map(x => x._1 * x._2)`.
+Never access tuple elements by positional accessors (`_._1`, `_._2`, etc.). Use pattern matching to destructure tuples into named bindings instead. Positional accessors are meaningless and convey no intent. Pattern matching gives each element a descriptive name, making the code self-documenting. For example: `nameValuePairs.map { case (name, _) => name }` instead of `nameValuePairs.map(_._1)`, and `priceAndQuantityPairs.map(x => x._1 * x._2)` becomes `priceAndQuantityPairs.map { case (price, quantity) => price * quantity }`.
+
+### 21. Pattern Matching on ADTs: Prefer Explicit Constructors over Wildcard
+When pattern matching on an ADT, prefer explicit data constructor matches over the wildcard pattern (`_`) — even when the remaining cases are handled identically. Use `|` (alternative patterns) to combine them. This makes the compiler's exhaustiveness check work for you: when a new variant is added to the ADT, the compiler warns about the non-exhaustive match instead of silently routing the new case through the wildcard. Example — given the ADT:
+
+```scala
+// Scala 2
+sealed trait Foobar
+object Foobar {
+  case object Foo extends Foobar
+  final case class Bar(n: Int) extends Foobar
+  case object Baz extends Foobar
+  final case class Qux(s: String) extends Foobar
+}
+
+// Scala 3
+enum Foobar {
+  case Foo
+  case Bar(n: Int)
+  case Baz
+  case Qux(s: String)
+}
+```
+
+Prefer:
+```scala
+foobar match {
+  case Foo         => println("It's Foo!")
+  case Bar(n)      => println(s"The bar value is $n")
+  case Baz | Qux(_) => println("Neither Foo nor Bar")
+}
+```
+
+Instead of:
+```scala
+foobar match {
+  case Foo    => println("It's Foo!")
+  case Bar(n) => println(s"The bar value is $n")
+  case _      => println("Neither Foo nor Bar")
+}
+```
 
 ## How to Apply
 
@@ -103,3 +143,4 @@ When **refactoring existing Scala code**: scan for violations of the rules above
 - Methods defined directly in case class bodies instead of as extension methods in companion objects
 - Default parameter values hiding semantics, smuggling policy, or encouraging oversized function signatures
 - Tuple element access via `_._1`, `_._2` instead of pattern matching (e.g. `{ case (name, _) => name }`)
+- Wildcard (`_`) pattern used when matching on an ADT — replace with explicit constructors combined via `|` so exhaustiveness checking catches new variants

--- a/skills/2020-hindsight-scala/references/practices.md
+++ b/skills/2020-hindsight-scala/references/practices.md
@@ -23,6 +23,7 @@ Reference: https://2020-hindsight-scala.kevinly.dev/docs/
 18. [Separate Operations from Data in Case Classes](#18-separate-operations-from-data-in-case-classes)
 19. [Do Not Use Default Parameters](#19-do-not-use-default-parameters)
 20. [Tuple: Use Pattern Matching Instead of `_._1`, `_._2`](#20-tuple-use-pattern-matching-instead-of-__1-__2)
+21. [Pattern Matching on ADTs: Prefer Explicit Constructors over Wildcard](#21-pattern-matching-on-adts-prefer-explicit-constructors-over-wildcard)
 
 ---
 
@@ -849,3 +850,57 @@ triples.map(t => t._1 + t._2 + t._3)
 // Good:
 triples.map { case (a, b, c) => a + b + c }
 ```
+
+---
+
+## 21. Pattern Matching on ADTs: Prefer Explicit Constructors over Wildcard
+
+When pattern matching on an ADT (sealed trait hierarchy in Scala 2, `enum` in Scala 3), prefer explicit data constructor matches to the wildcard pattern (`_`) — even when the remaining variants are handled identically. Combine them with `|` (alternative patterns) instead.
+
+**Why?**
+- The wildcard silently swallows future variants. If someone adds a new case to the ADT, the compiler has no way to warn you — the new variant simply falls into the wildcard branch, which is almost never what you want.
+- Explicit constructor matches give you the compiler's exhaustiveness check for free: adding a new variant produces a non-exhaustive match warning at every call site, forcing an intentional decision at each one.
+- Explicit names at the match site document *which* variants share behavior, instead of leaving the reader to infer it.
+
+**Example ADT — Scala 2:**
+```scala
+sealed trait Foobar
+object Foobar {
+  case object Foo extends Foobar
+  final case class Bar(n: Int) extends Foobar
+  case object Baz extends Foobar
+  final case class Qux(s: String) extends Foobar
+}
+```
+
+**Example ADT — Scala 3:**
+```scala
+enum Foobar {
+  case Foo
+  case Bar(n: Int)
+  case Baz
+  case Qux(s: String)
+}
+```
+
+**Good — explicit constructors combined with `|`:**
+```scala
+foobar match {
+  case Foo          => println("It's Foo!")
+  case Bar(n)       => println(s"The bar value is $n")
+  case Baz | Qux(_) => println("Neither Foo nor Bar")
+}
+```
+
+**Bad — wildcard pattern:**
+```scala
+foobar match {
+  case Foo    => println("It's Foo!")
+  case Bar(n) => println(s"The bar value is $n")
+  case _      => println("Neither Foo nor Bar")
+}
+```
+
+If a new variant `case Quux` is later added to `Foobar`, the wildcard version compiles with no warning and silently routes `Quux` through the "Neither Foo nor Bar" branch. The explicit version triggers a non-exhaustive match warning and forces the author to decide what `Quux` should do.
+
+**Exception:** The wildcard is still appropriate when matching on an open (non-sealed) type where exhaustiveness checking does not apply — e.g. matching on `Any`, `String`, `Int`, or a non-sealed class hierarchy.


### PR DESCRIPTION
# Add a new rule preferring explicit constructors over wildcards in ADT pattern matching to the 2020 Hindsight Scala skill

This commit introduces rule #21, "Pattern Matching on ADTs: Prefer Explicit Constructors over Wildcard", to ensure compiler exhaustiveness checks can properly warn developers when new variants are added to an ADT (sealed trait or enum). It updates both the main skill description and the detailed practices reference with Scala 2 and Scala 3 examples demonstrating how to combine explicit data constructor matches using alternative patterns (`|`) instead of relying on the wildcard pattern (`_`).

Additionally, this commit:
- Adds the new wildcard pattern rule to the refactoring checklist
- Slightly refines the code example phrasing in rule #20 (tuple destructuring) for better readability