### PR TITLE
Rework `setup-metals-mcp` and `setup-serena-mcp` to work in both Claude Code CLI and "Code" in the Claude Desktop app

### DIFF
--- a/skills/setup-metals-mcp/SKILL.md
+++ b/skills/setup-metals-mcp/SKILL.md
@@ -1,57 +1,105 @@
 ---
 name: setup-metals-mcp
-description: Creates or updates .mcp.json in the current Scala project directory to configure metals-mcp. Use this skill when the user wants to add metals-mcp to a project, says "setup metals-mcp", "add metals-mcp config", "set up metals-mcp for this project", "configure metals-mcp here", or is in a Scala project and asks to wire up any metals MCP integration.
+description: Configures metals-mcp for the current Scala project so it works identically in the Claude Code CLI and in "Code" inside the Claude Desktop app. Writes a committed self-locating wrapper script plus a machine-local .mcp.json. Use when the user wants to add metals-mcp to a project, says "setup metals-mcp", "add metals-mcp config", "configure metals-mcp here", or is in a Scala project and asks to wire up any metals MCP integration.
 ---
 
 # setup-metals-mcp
 
-Configures metals-mcp for the current Scala project by writing (or updating) `.mcp.json`
-in the current working directory.
+Configures metals-mcp for the current Scala project so the **same setup works in both**:
 
-## Why these two args are both required
+- the **Claude Code CLI** (`claude` in a terminal), and
+- **"Code" inside the Claude Desktop app** (embedded Claude Code — same engine as the CLI).
 
-metals-mcp will fail at startup without them:
+This does **not** target the Claude Desktop app's *plain chat* (that reads a separate global
+`claude_desktop_config.json` and has no project concept). This skill is only about Claude Code's
+project-level `.mcp.json`.
 
-- `--workspace <path>` — metals-mcp does not auto-detect the project directory
-- `--transport stdio` — the default transport is HTTP (Undertow); Claude Code expects stdio
-  and times out after 30s waiting for a stdio handshake that never comes
+## Why a wrapper script instead of `$PWD`
 
-## Config to write
+metals-mcp needs the absolute workspace path (`--workspace`); it does not auto-detect the project.
+The obvious approach — `sh -c 'metals-mcp --workspace "$PWD" ...'` — is **not reliable**, because
+of a confirmed open bug ([claude-code#75266](https://github.com/anthropics/claude-code/issues/75266)):
 
-Use `sh -c` so `$PWD` expands to the project root at process-launch time, rather than
-hardcoding an absolute path. This keeps the config portable — it works even if the project
-is moved, renamed, or cloned to a different location.
+- When Claude Code runs **embedded in the Claude Desktop app**, it launches stdio MCP servers with
+  `cwd = $HOME` instead of the project root. So `$PWD` (and any relative `command` path) resolves to
+  the home directory, and metals opens the wrong workspace. The CLI is unaffected, but we want one
+  config that works in both.
+- `${CLAUDE_PROJECT_DIR}` does **not** help in the `command`/`args` position: Claude Code does not
+  populate it in the server-launch environment there. `claude mcp list` reports
+  `Missing environment variables: CLAUDE_PROJECT_DIR` if you try. (Verified against Claude Code
+  2.1.x.)
 
-The metals-mcp entry to add:
+The robust fix is a **self-locating wrapper script** committed inside the project. The wrapper
+derives the project root from **its own on-disk location**, which is independent of the launcher's
+cwd — so it computes the correct `--workspace` in both the CLI and the embedded app. The only piece
+that must be cwd-independent is the path to the wrapper itself, so `.mcp.json` points at it by
+**absolute path** (see the portability note below).
+
+## Files this skill manages
+
+1. `<project>/.claude/metals-mcp.sh` — committed, portable, self-locating wrapper.
+2. `<project>/.mcp.json` — machine-local (absolute path inside), **gitignored**, regenerated per
+   machine by re-running this skill.
+3. `<project>/.gitignore` — ensure `.mcp.json` is ignored.
+
+### Wrapper script: `.claude/metals-mcp.sh`
+
+POSIX `sh`, no `readlink -f` (BSD `readlink` on older macOS lacks `-f`); uses `pwd -P` to resolve
+the script's directory:
+
+```sh
+#!/bin/sh
+# Self-locate the project root from this script's own path, independent of cwd.
+# .claude/metals-mcp.sh  ->  project root is one level up from .claude/
+scriptdir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+root=$(CDPATH= cd -- "$scriptdir/.." && pwd -P)
+exec metals-mcp --workspace "$root" --transport stdio
+```
+
+`--transport stdio` is still required: metals-mcp defaults to HTTP (Undertow) and Claude Code
+expects stdio (it times out after 30s otherwise).
+
+### `.mcp.json` entry (absolute `command`)
+
+The skill fills in the real absolute path to the wrapper at run time:
 
 ```json
 "metals-mcp": {
   "type": "stdio",
-  "command": "sh",
-  "args": ["-c", "metals-mcp --workspace \"$PWD\" --transport stdio"]
+  "command": "/absolute/path/to/project/.claude/metals-mcp.sh"
 }
 ```
 
 ## Steps
 
-1. Check whether `.mcp.json` already exists in the current directory.
-   - If it exists: read and parse it.
-   - If not: start from `{"mcpServers": {}}`.
+1. Determine the absolute path of the current project root (the directory `.mcp.json` will live in).
 
-2. Set `mcpServers["metals-mcp"]` to the entry above. Preserve all other `mcpServers` entries.
+2. Write `.claude/metals-mcp.sh` with the wrapper above. Create `.claude/` if needed. `chmod +x` it.
 
-3. Write the result back to `.mcp.json` with 2-space indentation.
+3. Read/parse `.mcp.json` if it exists (start from `{"mcpServers": {}}` otherwise). Set
+   `mcpServers["metals-mcp"]` to the entry above with the **absolute** wrapper path filled in.
+   Preserve all other `mcpServers` entries; overwrite an existing `metals-mcp` entry and note it.
+   Write back with 2-space indentation and a trailing newline.
 
-4. Tell the user:
-   - Whether `.mcp.json` was created fresh or updated
-   - To restart their Claude Code session for the change to take effect
+4. Ensure `.mcp.json` is gitignored: if `<project>/.gitignore` doesn't already ignore it, append a
+   `.mcp.json` line. (The wrapper under `.claude/` stays committed — it's portable.)
+
+5. Tell the user:
+   - That `.claude/metals-mcp.sh` (portable, commit it) and `.mcp.json` (machine-local, gitignored)
+     were written, and that teammates/other machines re-run this skill once to generate their own
+     `.mcp.json`.
+   - To restart their Claude Code session (CLI) or reopen the "Code" panel in Desktop for the
+     change to take effect.
+   - That this works in both the CLI and "Code" in the Desktop app, but **not** Desktop plain chat.
 
 ## Notes
 
-- `$PWD` is evaluated when Claude Code launches the MCP server process, which inherits
-  the working directory from the terminal. Always launch `claude` from the project root.
-- This is a project-level config — it only affects sessions opened in this directory.
-- If there is also a global metals-mcp entry in `~/.claude.json` with no `--workspace`,
-  it will conflict (that entry fails with `--workspace is required`). Suggest the user
-  remove it: `claude mcp remove --scope user metals-mcp`.
-- Requires metals-mcp v1.6.7+ (`cs install metals-mcp` via Coursier) and Java on PATH.
+- Requires metals-mcp v1.6.7+ (`cs install metals-mcp` via Coursier) and Java on PATH. Because the
+  embedded app launches with a minimal environment, if metals-mcp can't find `java`, add
+  `JAVA_HOME`/`PATH` via an `env` block on the `.mcp.json` entry, or set them inside the wrapper.
+- Why absolute path in `.mcp.json` (and hence gitignored): the path to the wrapper must not depend
+  on cwd, or bug #75266 breaks the embedded app. An absolute path is the only cwd-independent way to
+  *find* the wrapper; the wrapper itself is portable and committed. The `.mcp.json` is cheap to
+  regenerate — just re-run this skill.
+- If a global metals-mcp entry exists in `~/.claude.json` with no `--workspace`, it conflicts (fails
+  with `--workspace is required`). Suggest: `claude mcp remove --scope user metals-mcp`.

--- a/skills/setup-serena-mcp/SKILL.md
+++ b/skills/setup-serena-mcp/SKILL.md
@@ -1,82 +1,118 @@
 ---
 name: setup-serena-mcp
-description: Creates or updates .mcp.json in the current project directory to configure the serena MCP server for Claude Code. Invoke only when the user explicitly runs the `/setup-serena-mcp` slash command — do not trigger on general phrases like "set up serena" or "add an MCP server" unless that exact slash command is used.
+description: Configures the serena MCP server for the current project so it works identically in the Claude Code CLI and in "Code" inside the Claude Desktop app. Writes a committed self-locating wrapper script plus a machine-local .mcp.json. Invoke only when the user explicitly runs the `/setup-serena-mcp` slash command — do not trigger on general phrases like "set up serena" or "add an MCP server" unless that exact slash command is used.
 ---
 
 # setup-serena-mcp
 
-Configures the [serena](https://github.com/oraios/serena) MCP server for the current project
-by writing (or updating) `.mcp.json` in the current working directory.
+Configures the [serena](https://github.com/oraios/serena) MCP server for the current project so the
+**same setup works in both**:
+
+- the **Claude Code CLI** (`claude` in a terminal), and
+- **"Code" inside the Claude Desktop app** (embedded Claude Code — same engine as the CLI).
+
+This does **not** target the Claude Desktop app's *plain chat* (that reads a separate global
+`claude_desktop_config.json` and has no project concept). This skill is only about Claude Code's
+project-level `.mcp.json`.
 
 ## Invocation mechanism
 
-Use `uvx --from git+https://github.com/oraios/serena` so serena runs in an isolated,
-auto-fetched environment. This means the user doesn't need to pre-install serena or keep
-a global install in sync — `uvx` handles caching and resolution. The only prerequisite is
-`uv` on PATH (install via `curl -LsSf https://astral.sh/uv/install.sh | sh` on Unix).
+Use `uvx --from git+https://github.com/oraios/serena` so serena runs in an isolated, auto-fetched
+environment — no pre-install or global-sync needed. The only prerequisite is `uv` on PATH
+(`curl -LsSf https://astral.sh/uv/install.sh | sh` on Unix).
 
-## Why these flags matter
+## Why a wrapper script instead of `$PWD`
 
-serena runs correctly under Claude Code with both:
+serena needs the absolute project path (`--project`); it does not auto-detect the root. The obvious
+approach — `sh -c 'uvx ... --project "$PWD"'` — is **not reliable**, because of a confirmed open bug
+([claude-code#75266](https://github.com/anthropics/claude-code/issues/75266)):
 
-- `--context claude-code` — tunes serena's tool descriptions and reminders for Claude Code.
-  The default context is generic and drops some Claude Code-specific behavior that the
-  serena maintainers ship for this client.
-- `--project <path>` — serena does not auto-detect the project root; without it, serena
-  either refuses to start or operates on the wrong directory.
+- When Claude Code runs **embedded in the Claude Desktop app**, it launches stdio MCP servers with
+  `cwd = $HOME` instead of the project root. So `$PWD` (and any relative `command` path) resolves to
+  the home directory, and serena opens the wrong project. The CLI is unaffected, but we want one
+  config that works in both.
+- `${CLAUDE_PROJECT_DIR}` does **not** help in the `command`/`args` position: Claude Code does not
+  populate it in the server-launch environment there (`claude mcp list` reports
+  `Missing environment variables: CLAUDE_PROJECT_DIR`). Verified against Claude Code 2.1.x.
 
-## Config to write
+The robust fix is a **self-locating wrapper script** committed inside the project. The wrapper
+derives the project root from **its own on-disk location**, independent of the launcher's cwd — so
+it computes the correct `--project` in both the CLI and the embedded app. Only the path to the
+wrapper must be cwd-independent, so `.mcp.json` points at it by **absolute path** (see portability
+note).
 
-Wrap the launch in `sh -c` so `$PWD` expands to the project root at process-launch time
-rather than hardcoding an absolute path. This keeps `.mcp.json` portable — it survives
-the project being moved, renamed, or cloned to a different location, and it works for
-every teammate who checks out the repo.
+## Which serena context
 
-The serena entry to add:
+Use `--context claude-code` for both surfaces — "Code" in the Desktop app *is* Claude Code, so the
+same context applies. It tunes serena's tool descriptions and reminders for this client.
+
+## Files this skill manages
+
+1. `<project>/.claude/serena-mcp.sh` — committed, portable, self-locating wrapper.
+2. `<project>/.mcp.json` — machine-local (absolute path inside), **gitignored**, regenerated per
+   machine by re-running this skill.
+3. `<project>/.gitignore` — ensure `.mcp.json` is ignored.
+
+### Wrapper script: `.claude/serena-mcp.sh`
+
+POSIX `sh`, no `readlink -f` (BSD `readlink` on older macOS lacks `-f`); uses `pwd -P`:
+
+```sh
+#!/bin/sh
+# Self-locate the project root from this script's own path, independent of cwd.
+# .claude/serena-mcp.sh  ->  project root is one level up from .claude/
+scriptdir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+root=$(CDPATH= cd -- "$scriptdir/.." && pwd -P)
+exec uvx --from git+https://github.com/oraios/serena serena start-mcp-server \
+  --context claude-code --project "$root"
+```
+
+### `.mcp.json` entry (absolute `command`)
+
+The skill fills in the real absolute path to the wrapper at run time:
 
 ```json
 "serena": {
   "type": "stdio",
-  "command": "sh",
-  "args": [
-    "-c",
-    "uvx --from git+https://github.com/oraios/serena serena start-mcp-server --context claude-code --project \"$PWD\""
-  ]
+  "command": "/absolute/path/to/project/.claude/serena-mcp.sh"
 }
 ```
 
 ## Steps
 
-1. Check whether `.mcp.json` already exists in the current directory.
-   - If it exists: read and parse it. If the top-level shape is not
-     `{"mcpServers": {...}}`, stop and ask the user before overwriting — a different
-     shape likely means the file is managed by a tool you don't want to stomp on.
-   - If not: start from `{"mcpServers": {}}`.
+1. Determine the absolute path of the current project root (the directory `.mcp.json` will live in).
 
-2. Set `mcpServers["serena"]` to the entry above. Preserve all other `mcpServers` entries.
-   If a `serena` entry already exists, overwrite it and note the overwrite to the user.
+2. Write `.claude/serena-mcp.sh` with the wrapper above. Create `.claude/` if needed. `chmod +x` it.
 
-3. Write the result back to `.mcp.json` with 2-space indentation and a trailing newline.
+3. Read/parse `.mcp.json` if it exists. If the top-level shape is not `{"mcpServers": {...}}`, stop
+   and ask before overwriting (a different shape likely means the file is tool-managed). Otherwise
+   start from `{"mcpServers": {}}`. Set `mcpServers["serena"]` to the entry above with the
+   **absolute** wrapper path. Preserve other entries; overwrite an existing `serena` entry and note
+   it. Write back with 2-space indentation and a trailing newline.
 
-4. Tell the user:
-   - Whether `.mcp.json` was created fresh or updated, and whether an existing `serena`
-     entry was overwritten.
-   - To restart their Claude Code session for the change to take effect.
-   - That `uv` must be on PATH for serena to launch. If they don't have it:
-     `curl -LsSf https://astral.sh/uv/install.sh | sh`.
-   - That the first launch will be slow while `uvx` fetches and caches serena from git;
-     subsequent launches are fast.
+4. Ensure `.mcp.json` is gitignored: if `<project>/.gitignore` doesn't already ignore it, append a
+   `.mcp.json` line. (The wrapper under `.claude/` stays committed — it's portable.)
+
+5. Tell the user:
+   - That `.claude/serena-mcp.sh` (portable, commit it) and `.mcp.json` (machine-local, gitignored)
+     were written, and that teammates/other machines re-run this skill once to generate their own
+     `.mcp.json`.
+   - To restart their Claude Code session (CLI) or reopen the "Code" panel in Desktop.
+   - That `uv` must be on PATH; if missing: `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+   - That the first launch is slow while `uvx` fetches and caches serena from git; later launches
+     are fast.
+   - That this works in both the CLI and "Code" in the Desktop app, but **not** Desktop plain chat.
 
 ## Notes
 
-- `$PWD` is evaluated when Claude Code launches the MCP server process, which inherits
-  the working directory from the terminal. Launch `claude` from the project root so the
-  path resolves correctly.
-- This is a project-level config — it only affects sessions opened in this directory.
-  Commit `.mcp.json` to the repo if you want teammates to share the setup.
-- If there is also a global `serena` entry in `~/.claude.json` (e.g. from
-  `claude mcp add --scope user serena ...`), the project-level entry takes precedence for
-  sessions opened here, but the two configs can drift. If the user reports unexpected
-  behavior, suggest: `claude mcp remove --scope user serena`.
-- To pin a specific serena version instead of tracking `main`, change the `--from` target
-  to `git+https://github.com/oraios/serena@<tag-or-sha>`.
+- Why absolute path in `.mcp.json` (and hence gitignored): the wrapper path must not depend on cwd,
+  or bug #75266 breaks the embedded app. Absolute is the only cwd-independent way to *find* the
+  wrapper; the wrapper itself is portable and committed. Re-running this skill regenerates
+  `.mcp.json` cheaply.
+- Because the embedded app launches with a minimal environment, if `uv`/`uvx` isn't found, add its
+  directory to `PATH` via an `env` block on the `.mcp.json` entry, or hardcode the absolute `uvx`
+  path inside the wrapper (find it with `which uvx`).
+- To pin a serena version instead of tracking `main`, change the `--from` target in the wrapper to
+  `git+https://github.com/oraios/serena@<tag-or-sha>`.
+- If a global `serena` entry exists in `~/.claude.json`, the project entry takes precedence for
+  sessions here but the two can drift. If behavior is unexpected: `claude mcp remove --scope user serena`.


### PR DESCRIPTION
Rework `setup-metals-mcp` and `setup-serena-mcp` to work in both Claude Code CLI and "Code" in the Claude Desktop app

Previously these skills relied on an `sh -c` + `$PWD` trick to pass the workspace/project path. That breaks when Claude Code runs embedded in the Claude Desktop app ("Code"), which launches stdio MCP servers with cwd set to $HOME instead of the project root (claude-code#75266), so metals/serena would open the wrong directory.

`${CLAUDE_PROJECT_DIR}` in the `command` field is not a workaround either — it is not populated in the server-launch environment there (verified: the CLI reports "Missing environment variables: CLAUDE_PROJECT_DIR").

Both skills now generate a committed, portable self-locating wrapper script under `.claude/` that derives the project root from its own on-disk path (`pwd -P`, avoiding `readlink -f` which older macOS lacks), so it computes the correct path regardless of cwd. `.mcp.json` points at the wrapper by absolute path and is gitignored, regenerated per machine by re-running the skill. This works in both the CLI and "Code" in Desktop, but not Desktop plain chat.