### PR TITLE
Update `skills/riper-5`: Refine plan file naming conventions and execution workflow

### DIFF
--- a/skills/riper-5/SKILL.md
+++ b/skills/riper-5/SKILL.md
@@ -51,7 +51,12 @@ YOU MUST BEGIN EVERY SINGLE RESPONSE WITH YOUR CURRENT MODE IN BRACKETS. NO EXCE
   ```
 - Duration: Until I explicitly approve plan and signal to move to next mode
 - Output Format: Begin with `[MODE: PLAN]`, then ONLY specifications and implementation details
-- Once the plan is ready, the content should be stored in a markdown file in the `.ai` folder of the current project. Create the folder if it does not exist. The content of the plan file should remain unchanged from the original plan, without removing anything (e.g. the checklist, metadata for the AI agent's PLAN mode, etc.). This should be done before asking to proceed to the next mode so I can review the plan file for approval.
+- Once the plan is ready, the content should be stored in a markdown file in the `.ai` folder of the current project. Create the folder if it does not exist. The content of the plan file should remain unchanged from the original plan, without removing anything (e.g. the checklist, metadata for the AI agent's PLAN mode, etc.). This MUST be done before asking me to signal "ENTER EXECUTE MODE", so I can review the plan file and edit it if needed before execution.
+- Plan File Naming: Store the plan file under a `{yyyy-MM}` subfolder, named as follows:
+  - With an issue ID: `.ai/{yyyy-MM}/{yyyy-MM-dd}-issue-{id}-{short-summary}.md` (e.g. `.ai/2026-07/2026-07-13-issue-123-improve-ux.md`)
+  - Without an issue ID: `.ai/{yyyy-MM}/{yyyy-MM-dd}-{HHmm}-{short-summary}.md`, where `{HHmm}` is the current local time in 24-hour format (e.g. `.ai/2026-07/2026-07-13-1432-improve-ux.md`)
+  - `{short-summary}` is a brief kebab-case summary of the plan (e.g. `improve-ux`)
+  - Use the issue ID provided by me. If none was provided, use the time-based format — do not guess an issue ID.
 
 ### MODE 4: EXECUTE
 [MODE: EXECUTE]
@@ -60,6 +65,7 @@ YOU MUST BEGIN EVERY SINGLE RESPONSE WITH YOUR CURRENT MODE IN BRACKETS. NO EXCE
 - Permitted: ONLY implementing what was explicitly detailed in the approved plan
 - Forbidden: Any deviation, improvement, or creative addition not in the plan
 - Entry Requirement: ONLY enter after explicit "ENTER EXECUTE MODE" command from me
+- On Entry: Re-read the saved plan file first — I may have edited it after it was written — and follow the file's content, not the plan from the conversation
 - Deviation Handling: If ANY issue is found requiring deviation, IMMEDIATELY return to PLAN mode
 - Output Format: Begin with `[MODE: EXECUTE]`, then ONLY implementation matching the plan
 
@@ -92,3 +98,5 @@ Only transition modes when I explicitly signal with:
 - "ENTER REVIEW MODE"
 
 Without these exact signals, remain in your current mode.
+
+When asking me to signal "ENTER PLAN MODE", remind me to provide the issue ID (if one exists) so it can be used in the plan file name.


### PR DESCRIPTION
# Update `skills/riper-5`: Refine plan file naming conventions and execution workflow

- Add structured naming rules for plan files, requiring them to be saved in `.ai/{yyyy-MM}/` subdirectories using specific issue-based or time-based naming formats.
- Require the AI agent to save the plan file before prompting the user to signal "ENTER EXECUTE MODE", allowing the user time to review and edit the file.
- Instruct the agent to explicitly re-read the saved plan file upon entering EXECUTE mode to ensure any manual user edits are followed instead of relying on the conversation history.
- Add a rule to remind the user to provide an issue ID when asking them to signal "ENTER PLAN MODE".