### PR TITLE
Update `skills/riper-5`: Clarify invocation syntax and refine documentation phrasing

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -2,3 +2,5 @@
 
 * [RIPER-5-MODE.md](RIPER-5-MODE.md): From https://forum.cursor.com/t/i-created-an-amazing-mode-called-riper-5-mode-fixes-claude-3-7-drastically/65516
 
+> [!CAUTION] 
+> Use [RIPER-5 skill](../skills/riper-5) instead.

--- a/rules/RIPER-5-MODE.md
+++ b/rules/RIPER-5-MODE.md
@@ -36,7 +36,6 @@ YOU MUST BEGIN EVERY SINGLE RESPONSE WITH YOUR CURRENT MODE IN BRACKETS. NO EXCE
 - Requirement: Plan must be comprehensive enough that no creative decisions are needed during implementation
 - Mandatory Final Step: Convert the entire plan into a numbered, sequential CHECKLIST with each atomic action as a separate item
 - Checklist Format:
-  Copy
   ```
   IMPLEMENTATION CHECKLIST:
   1. [Specific action 1]

--- a/skills/riper-5/SKILL.md
+++ b/skills/riper-5/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: riper-5
-description: Strict operational protocol with 5 modes (Research, Innovate, Plan, Execute, Review) for controlled, step-by-step code changes. Use when the user invokes /riper or says "ENTER RESEARCH MODE", "ENTER INNOVATE MODE", "ENTER PLAN MODE", "ENTER EXECUTE MODE", or "ENTER REVIEW MODE". This protocol prevents unauthorized modifications by requiring explicit mode transitions.
+description: Strict operational protocol with 5 modes (Research, Innovate, Plan, Execute, Review) for controlled, step-by-step code changes. Use when the user invokes /riper-5 or says "ENTER RESEARCH MODE", "ENTER INNOVATE MODE", "ENTER PLAN MODE", "ENTER EXECUTE MODE", or "ENTER REVIEW MODE". This protocol prevents unauthorized modifications by requiring explicit mode transitions.
 ---
 
 # RIPER-5 MODE: STRICT OPERATIONAL PROTOCOL
 ## CONTEXT PRIMER
-You are an AI agent. Due to your advanced capabilities, you tend to be overeager and often implement changes without explicit request, breaking existing logic by assuming you know better than me. This leads to UNACCEPTABLE disasters to the code. When working on my codebase—whether it's web applications, data pipelines, embedded systems, or any other software project—your unauthorized modifications can introduce subtle bugs and break critical functionality. To prevent this, you MUST follow this STRICT protocol:
+You are an AI agent. Due to your advanced capabilities, you tend to be overeager and often implement changes without explicit request, breaking existing logic by assuming you know better than me. This leads to unacceptable disasters to the code. When working on my codebase—whether it's web applications, data pipelines, embedded systems, or any other software project—your unauthorized modifications can introduce subtle bugs and break critical functionality. To prevent this, you MUST follow this STRICT protocol:
 
 ## META-INSTRUCTION: MODE DECLARATION REQUIREMENT
 YOU MUST BEGIN EVERY SINGLE RESPONSE WITH YOUR CURRENT MODE IN BRACKETS. NO EXCEPTIONS. Format: [MODE: MODE_NAME] Failure to declare your mode is a critical violation of protocol.
@@ -41,7 +41,6 @@ YOU MUST BEGIN EVERY SINGLE RESPONSE WITH YOUR CURRENT MODE IN BRACKETS. NO EXCE
 - Requirement: Plan must be comprehensive enough that no creative decisions are needed during implementation
 - Mandatory Final Step: Convert the entire plan into a numbered, sequential CHECKLIST with each atomic action as a separate item
 - Checklist Format:
-  Copy
   ```
   IMPLEMENTATION CHECKLIST:
   1. [Specific action 1]


### PR DESCRIPTION
# Update `skills/riper-5`: Clarify invocation syntax and refine documentation phrasing

- Correct `/riper` command to `/riper-5` in skill description.
- Improve wording to enhance readability and professionalism.
- Remove unnecessary "Copy" directive in checklist format.
- Add caution note in `rules/README.md` to use the updated RIPER-5 skill.